### PR TITLE
More development into Business Address association

### DIFF
--- a/sql/business_addrs.sql
+++ b/sql/business_addrs.sql
@@ -15,7 +15,6 @@ CREATE TABLE  hpd_business_addresses AS (
        FROM hpd_contacts
        WHERE
                 (BusinessHouseNumber IS NOT NULL AND BusinessStreetName IS NOT NULL AND  BusinessZip IS NOT NULL)
-                -- AND (registrationcontacttype = 'CorporateOwner')
                 GROUP BY BusinessHouseNumber, BusinessStreetName, BusinessZip, BusinessApartment);
 
 ALTER TABLE hpd_business_addresses ADD COLUMN id serial;
@@ -25,6 +24,9 @@ ALTER TABLE hpd_business_addresses ADD PRIMARY KEY (id);
 ALTER TABLE hpd_business_addresses ADD COLUMN uniqcorpnames text[];
 ALTER TABLE hpd_business_addresses ADD COLUMN uniqownernames text[];
 
+-- remove blank fields from owner columns
+UPDATE hpd_business_addresses SET ownernames = array_remove(ownernames, ' ');
+
 UPDATE hpd_business_addresses SET uniqcorpnames = corporationnames;
 UPDATE hpd_business_addresses SET uniqownernames = ownernames;
 
@@ -32,6 +34,8 @@ UPDATE hpd_business_addresses SET uniqregids = anyarray_uniq(regids);
 -- there appears to be at least row that causes an error with anyarray_unique, which is 'fixed' by the WHERE clause here.
 UPDATE hpd_business_addresses SET uniqcorpnames = anyarray_uniq(corporationnames) WHERE array_length(corporationnames, 1) > 0;
 UPDATE hpd_business_addresses SET uniqownernames = anyarray_uniq(ownernames) WHERE array_length(ownernames, 1) > 0;
+
+
 
 -- Add Lat, Lng.
 ALTER TABLE hpd_business_addresses ADD COLUMN lat numeric;

--- a/sql/business_addrs.sql
+++ b/sql/business_addrs.sql
@@ -1,0 +1,40 @@
+BEGIN;
+
+DROP TABLE IF EXISTS hpd_business_addresses;
+
+CREATE TABLE  hpd_business_addresses AS (
+       SELECT BusinessHouseNumber,
+              BusinessStreetName,
+              BusinessZip,
+              BusinessApartment,
+              count (*) as numberOfContacts,
+              anyarray_remove_null(array_agg(CorporationName)) as corporationnames,
+              anyarray_remove_null(array_agg(concat(firstname, ' ', lastname))) as ownernames,
+              array_agg(registrationID) as regids,
+              anyarray_uniq(array_agg(registrationID)) as uniqregids
+       FROM hpd_contacts
+       WHERE
+                (BusinessHouseNumber IS NOT NULL AND BusinessStreetName IS NOT NULL AND  BusinessZip IS NOT NULL)
+                -- AND (registrationcontacttype = 'CorporateOwner')
+                GROUP BY BusinessHouseNumber, BusinessStreetName, BusinessZip, BusinessApartment);
+
+ALTER TABLE hpd_business_addresses ADD COLUMN id serial;
+UPDATE hpd_business_addresses SET id = DEFAULT;
+
+ALTER TABLE hpd_business_addresses ADD PRIMARY KEY (id);
+ALTER TABLE hpd_business_addresses ADD COLUMN uniqcorpnames text[];
+ALTER TABLE hpd_business_addresses ADD COLUMN uniqownernames text[];
+
+UPDATE hpd_business_addresses SET uniqcorpnames = corporationnames;
+UPDATE hpd_business_addresses SET uniqownernames = ownernames;
+
+UPDATE hpd_business_addresses SET uniqregids = anyarray_uniq(regids);
+-- there appears to be at least row that causes an error with anyarray_unique, which is 'fixed' by the WHERE clause here.
+UPDATE hpd_business_addresses SET uniqcorpnames = anyarray_uniq(corporationnames) WHERE array_length(corporationnames, 1) > 0;
+UPDATE hpd_business_addresses SET uniqownernames = anyarray_uniq(ownernames) WHERE array_length(ownernames, 1) > 0;
+
+-- Add Lat, Lng.
+ALTER TABLE hpd_business_addresses ADD COLUMN lat numeric;
+ALTER TABLE hpd_business_addresses ADD COLUMN lng numeric;
+
+COMMIT;

--- a/sql/functions.sql
+++ b/sql/functions.sql
@@ -10,3 +10,74 @@ RETURNS TABLE (id int, buildingscount int, uniqnames text[], businesshousenumber
 	     businesszip
       FROM hpd_corporate_owners WHERE get_corporate_owner_info_for_regid.regid = ANY(regids)
 $$ LANGUAGE SQL;
+
+
+-- Returns one or more Registered Business Address (and associated info) from an address
+DROP FUNCTION IF EXISTS get_rbas_from_addr(text, text, text);
+
+CREATE OR REPLACE FUNCTION get_rbas_from_addr(_housenumber text, _streetname text, _boro text)
+RETURNS TABLE (
+  id int,
+  businesshousenumber text,
+  businessstreetname text,
+  businesszip text,
+  businessapartment text,
+  numberofcontacts bigint,
+  numberofbuildings int,
+  uniqregids integer[],
+  uniqcorpnames text[],
+  uniqownernames text[]
+) AS $$
+  SELECT
+    id,
+    businesshousenumber,
+    businessstreetname,
+    businesszip,
+    businessapartment,
+    numberofcontacts,
+    array_length(uniqregids,1) AS numberofbuildings,
+    uniqregids,
+    uniqcorpnames,
+    uniqownernames
+  FROM hpd_business_addresses AS rbas
+  INNER JOIN (
+    -- get registrationid from address
+    SELECT DISTINCT registrationid
+    FROM hpd_registrations_grouped_by_bbl r
+    WHERE
+      r.housenumber = _housenumber AND
+      r.streetname = _streetname AND
+      r.boro = _boro
+  ) r ON (r.registrationid = any(rbas.uniqregids))
+$$ LANGUAGE SQL;
+
+
+-- Returns address info from an array of regids, which are supplied as a
+-- comma delineated string
+DROP FUNCTION IF EXISTS get_addrs_from_regids(text);
+
+CREATE OR REPLACE FUNCTION get_addrs_from_regids(_regids text)
+RETURNS TABLE (
+  housenumber text,
+  streetname text,
+  boro text,
+  zip text,
+  lat numeric,
+  lng numeric,
+  regid int,
+  bbl text
+) AS $$
+  SELECT
+    housenumber,
+    streetname,
+    boro,
+    zip,
+    lat,
+    lng,
+    regid,
+    bbl
+  FROM hpd_registrations_grouped_by_bbl AS r
+  INNER JOIN (
+    SELECT unnest(string_to_array(_regids, ','))::int AS regid
+  ) regids ON (r.registrationid = regids.regid)
+$$ LANGUAGE SQL;

--- a/sql/functions.sql
+++ b/sql/functions.sql
@@ -65,7 +65,9 @@ RETURNS TABLE (
   lat numeric,
   lng numeric,
   regid int,
-  bbl text
+  bbl text,
+  corpnames text[],
+  ownernames json
 ) AS $$
   SELECT
     housenumber,
@@ -75,8 +77,10 @@ RETURNS TABLE (
     lat,
     lng,
     regid,
-    bbl
-  FROM hpd_registrations_grouped_by_bbl AS r
+    bbl,
+    corpnames,
+    ownernames
+  FROM hpd_registrations_grouped_by_bbl_with_contacts AS r
   INNER JOIN (
     SELECT unnest(string_to_array(_regids, ','))::int AS regid
   ) regids ON (r.registrationid = regids.regid)

--- a/sql/registrations_grouped_by_bbl_with_contacts.sql
+++ b/sql/registrations_grouped_by_bbl_with_contacts.sql
@@ -1,0 +1,37 @@
+DROP TABLE IF EXISTS hpd_registrations_grouped_by_bbl_with_contacts;
+
+CREATE TABLE hpd_registrations_grouped_by_bbl_with_contacts
+as SELECT
+  registrations.housenumber,
+  registrations.streetname,
+  registrations.zip,
+  registrations.boro,
+  registrations.lat,
+  registrations.lng,
+  registrations.registrationid,
+  registrations.bbl,
+  contacts.corpnames,
+  contacts.ownernames
+FROM hpd_registrations_grouped_by_bbl AS registrations
+LEFT JOIN (
+  SELECT
+    -- collect the various corporation names
+    anyarray_uniq(anyarray_remove_null(array_agg(corporationname))) as corpnames,
+
+    -- craziness! json in postgres!
+    -- this will filter out the (typically blank) CorporateOwner human names and any other blanks
+    -- using json makes this nice to get from a query but also allows us to store key/value pairs
+    -- which both the title and owner's concatenated first and last name. 
+    json_agg(json_build_object('title', registrationcontacttype, 'value', (firstname || ' ' || lastname)))
+      FILTER (
+        WHERE registrationcontacttype != 'CorporateOwner' AND
+        firstname IS NOT NULL AND
+        lastname IS NOT NULL
+      )
+      AS ownernames,
+    registrationid
+  FROM hpd_contacts
+  GROUP BY registrationid
+) contacts ON (registrations.registrationid = contacts.registrationid);
+
+create index on hpd_registrations_grouped_by_bbl_with_contacts (registrationid);


### PR DESCRIPTION
This expands on the various methods to align properties via registered business addresses with HPD.

- Creates a `hpd_business_addresses` table which expands on `hpd_corporate_owners` by looking at _all_ business addresses, not just ones associated with `CorporateOwner` in `hpd_contacts`. This results in a substantially larger table: 154910 rows vs. 36384.
- This new table also clusters "known associates" in `ownernames` and `uniqownernames` while also removing blank entries.
- Added some useful functions for querying this data. `get_rbas_from_addr()` takes housenumber, streetname, boro parameters and returns **0 or more** entries from `hpd_business_addresses`. This is significant as some properties have more than one business address associated with them.
- The function `get_addrs_from_regids()` then takes an array of `regids` from the previous function and returns the property location details. It takes the array as represented by a comma delineated string, which is used when making calls from the server and seemed like the simplest approach.

Next up: fuzzy searching of owner and corporation names!