### PR TITLE
Expanding ownership mapping functions

### DIFF
--- a/sql/array_cat_agg.sql
+++ b/sql/array_cat_agg.sql
@@ -1,0 +1,6 @@
+--  see: https://stackoverflow.com/questions/22677463/how-to-merge-all-integer-arrays-from-all-records-into-single-array-in-postgres/22677955#22677955
+DROP AGGREGATE IF EXISTS array_cat_agg(anyarray);
+CREATE AGGREGATE array_cat_agg(anyarray) (
+  SFUNC=array_cat,
+  STYPE=anyarray
+);

--- a/sql/bisaddr_search.sql
+++ b/sql/bisaddr_search.sql
@@ -1,0 +1,15 @@
+-- Given a regid, cross reference with uniqregid fields in the business_address table
+DROP FUNCTION IF EXISTS get_regids_from_regid_by_bisaddr(integer);
+
+CREATE OR REPLACE FUNCTION get_regids_from_regid_by_bisaddr(_regid integer)
+RETURNS TABLE (
+  uniqregids integer[]
+) AS $$
+  SELECT
+    anyarray_uniq(array_cat_agg(q.uniqregids)) as uniqregids
+  FROM (
+    SELECT rbas.uniqregids
+    FROM hpd_business_addresses AS rbas
+    WHERE _regid = any(rbas.uniqregids)
+  ) AS q;
+$$ LANGUAGE SQL;

--- a/sql/combined_search.sql
+++ b/sql/combined_search.sql
@@ -1,0 +1,47 @@
+-- One grand function to rule them all
+-- This takes in a given bbl, and grabs the regid (btw there are more regids than bbls, so a bbl could have multiple regids?)
+-- Using that, we use a few different functions that follow a (regid -> regids) convention
+-- They use things like shared business addresses and fuzzy name lookup. This UNIONs those queries, merges them,
+-- And then populates with relevant address info!
+DROP FUNCTION IF EXISTS get_assoc_addrs_from_bbl(text);
+
+CREATE OR REPLACE FUNCTION get_assoc_addrs_from_bbl(_bbl text)
+RETURNS TABLE (
+  housenumber text,
+  streetname text,
+  boro text,
+  zip text,
+  lat numeric,
+  lng numeric,
+  regid int,
+  bbl text,
+  corpnames text[],
+  businessaddrs text[],
+  ownernames json
+) AS $$
+  SELECT
+    housenumber,
+    streetname,
+    boro,
+    zip,
+    lat,
+    lng,
+    regid,
+    bbl,
+    corpnames,
+    businessaddrs,
+    ownernames
+  FROM hpd_registrations_grouped_by_bbl_with_contacts AS r
+  INNER JOIN (
+    (SELECT DISTINCT registrationid FROM hpd_registrations_grouped_by_bbl_with_contacts r WHERE r.bbl = _bbl) userreg
+    LEFT JOIN LATERAL
+    (
+      SELECT
+        unnest(anyarray_uniq(array_cat_agg(merged.uniqregids))) AS regid
+      FROM (
+        SELECT uniqregids FROM get_regids_from_regid_by_bisaddr(userreg.registrationid)
+        UNION SELECT uniqregids FROM get_regids_from_regid_by_owners(userreg.registrationid)
+      ) AS merged
+    ) merged2 ON true
+  ) assocregids ON (r.registrationid = assocregids.regid);
+$$ LANGUAGE SQL;

--- a/sql/contacts_clean_up.sql
+++ b/sql/contacts_clean_up.sql
@@ -1,0 +1,5 @@
+-- Various things to clean up hpd contacts craziness
+
+-- For some reason there are a lot of #'s instead of names
+UPDATE hpd_contacts SET firstname = regexp_replace(firstname, '#', '', 'g');
+UPDATE hpd_contacts SET lastname = regexp_replace(lastname, '#', '', 'g');

--- a/sql/functions.sql
+++ b/sql/functions.sql
@@ -11,49 +11,9 @@ RETURNS TABLE (id int, buildingscount int, uniqnames text[], businesshousenumber
       FROM hpd_corporate_owners WHERE get_corporate_owner_info_for_regid.regid = ANY(regids)
 $$ LANGUAGE SQL;
 
-
--- Returns one or more Registered Business Address (and associated info) from an address
-DROP FUNCTION IF EXISTS get_rbas_from_addr(text, text, text);
-
-CREATE OR REPLACE FUNCTION get_rbas_from_addr(_housenumber text, _streetname text, _boro text)
-RETURNS TABLE (
-  id int,
-  businesshousenumber text,
-  businessstreetname text,
-  businesszip text,
-  businessapartment text,
-  numberofcontacts bigint,
-  numberofbuildings int,
-  uniqregids integer[],
-  uniqcorpnames text[],
-  uniqownernames text[]
-) AS $$
-  SELECT
-    id,
-    businesshousenumber,
-    businessstreetname,
-    businesszip,
-    businessapartment,
-    numberofcontacts,
-    array_length(uniqregids,1) AS numberofbuildings,
-    uniqregids,
-    uniqcorpnames,
-    uniqownernames
-  FROM hpd_business_addresses AS rbas
-  INNER JOIN (
-    -- get registrationid from address
-    SELECT DISTINCT registrationid
-    FROM hpd_registrations_grouped_by_bbl r
-    WHERE
-      r.housenumber = _housenumber AND
-      r.streetname = _streetname AND
-      r.boro = _boro
-  ) r ON (r.registrationid = any(rbas.uniqregids))
-$$ LANGUAGE SQL;
-
-
 -- Returns address info from an array of regids, which are supplied as a
 -- comma delineated string
+-- NOTE: now using combined_search.sql to populated the addr info from the regid instead
 DROP FUNCTION IF EXISTS get_addrs_from_regids(text);
 
 CREATE OR REPLACE FUNCTION get_addrs_from_regids(_regids text)

--- a/sql/people_search.sql
+++ b/sql/people_search.sql
@@ -1,0 +1,45 @@
+-- http://blog.scoutapp.com/articles/2016/07/12/how-to-make-text-searches-in-postgresql-faster-with-trigram-similarity
+-- http://www.postgresonline.com/journal/archives/169-Fuzzy-string-matching-with-Trigram-and-Trigraphs.html
+
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+CREATE INDEX IF NOT EXISTS people_last_name_idx ON hpd_contacts USING GIN(lastname gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS people_first_name_idx ON hpd_contacts USING GIN(firstname gin_trgm_ops);
+
+
+-- This should be fairly self-explanatory. Provide name, use triagram lookup to get assoc. regids
+DROP FUNCTION IF EXISTS get_regids_from_name(text, text);
+
+CREATE OR REPLACE FUNCTION get_regids_from_name(_firstname text, _lastname text)
+RETURNS TABLE (
+  uniqregids integer[]
+) AS $$
+  SELECT
+    array_agg(q.registrationid) as uniqregids
+  FROM (
+    SELECT DISTINCT ON (registrationid) registrationid FROM hpd_contacts
+    WHERE firstname % _firstname AND similarity(firstname, _firstname) > 0.5 
+      AND lastname % _lastname AND similarity(lastname, _lastname) > 0.5
+  ) AS q;
+$$ LANGUAGE SQL;
+
+
+-- Given a registrationid, return associated properties from the names of CorporateOwners, HeadOfficers, and IndividualOwners
+-- The reason we include CorporateOwner is that sometimes they'll register a person name, this is useful
+DROP FUNCTION IF EXISTS get_regids_from_regid_by_owners(integer);
+
+CREATE OR REPLACE FUNCTION get_regids_from_regid_by_owners(_regid integer)
+RETURNS TABLE (
+  uniqregids integer[]
+) AS $$
+  SELECT
+    anyarray_uniq(array_cat_agg(q.uniqregids)) as uniqregids
+  FROM (
+    SELECT c.firstname, c.lastname, f.uniqregids
+    FROM hpd_contacts c,
+    LATERAL get_regids_from_name(c.firstname, c.lastname) f
+    WHERE c.registrationid = _regid AND
+    firstname IS NOT NULL and lastname IS NOT NULL AND
+    (c.registrationcontacttype = 'CorporateOwner' OR c.registrationcontacttype = 'HeadOfficer' OR c.registrationcontacttype = 'IndividualOwner')
+  ) AS q;
+$$ LANGUAGE SQL;

--- a/sql/registrations_clean_up.sql
+++ b/sql/registrations_clean_up.sql
@@ -2,7 +2,7 @@ UPDATE hpd_registrations SET streetname = regexp_replace( streetname, ' AVE$|-AV
 
 
 -- unsure what to do about the conflict with streets?
---UPDATE registrations SET streetname = regexp_replace( streetname, '^ST.? ', 'SAINT ', 'g') WHERE streetname ~  '^ST.? .*';
+UPDATE hpd_registrations SET streetname = regexp_replace( streetname, '^ST.? ', 'SAINT ', 'g') WHERE streetname ~  '^ST.? .*';
 
 -- remove periods
 
@@ -29,7 +29,7 @@ UPDATE hpd_registrations SET streetname = regexp_replace( streetname, '^BCH ', '
 UPDATE hpd_registrations SET streetname = regexp_replace( streetname, '^E ', 'EAST ');
 UPDATE hpd_registrations SET streetname = regexp_replace( streetname, '^W ', 'WEST ');
 UPDATE hpd_registrations SET streetname = regexp_replace( streetname, '^N ', 'NORTH ');
-UPDATE hpd_registrations SET streetname = regexp_replace( streetname, '^S ', 'SOUTH '); 
+UPDATE hpd_registrations SET streetname = regexp_replace( streetname, '^S ', 'SOUTH ');
 
 --UPDATE registrations SET BusinessApartment = regexp_replace( BusinessApartment, '_|\.', '', 'g');
 

--- a/sql/registrations_grouped_by_bbl_with_contacts.sql
+++ b/sql/registrations_grouped_by_bbl_with_contacts.sql
@@ -1,5 +1,8 @@
 DROP TABLE IF EXISTS hpd_registrations_grouped_by_bbl_with_contacts;
 
+-- This is mainly used as an easy way to provide contact info on request, not a replacement
+-- for cross-table analysis. Hence why the corpnames, businessaddrs, and ownernames are simplified
+-- with JSON and such.
 CREATE TABLE hpd_registrations_grouped_by_bbl_with_contacts
 as SELECT
   registrations.housenumber,
@@ -11,6 +14,7 @@ as SELECT
   registrations.registrationid,
   registrations.bbl,
   contacts.corpnames,
+  contacts.businessaddrs,
   contacts.ownernames
 FROM hpd_registrations_grouped_by_bbl AS registrations
 LEFT JOIN (
@@ -18,10 +22,18 @@ LEFT JOIN (
     -- collect the various corporation names
     anyarray_uniq(anyarray_remove_null(array_agg(corporationname))) as corpnames,
 
+    -- concat_ws ignores NULL values
+    anyarray_uniq(anyarray_remove_null(
+      array_agg(
+        nullif(concat_ws(' ', businesshousenumber, businessstreetname, businessapartment, businesszip), '')
+      )
+    ))
+    as businessaddrs,
+
     -- craziness! json in postgres!
     -- this will filter out the (typically blank) CorporateOwner human names and any other blanks
     -- using json makes this nice to get from a query but also allows us to store key/value pairs
-    -- which both the title and owner's concatenated first and last name. 
+    -- which both the title and owner's concatenated first and last name.
     json_agg(json_build_object('title', registrationcontacttype, 'value', (firstname || ' ' || lastname)))
       FILTER (
         WHERE registrationcontacttype != 'CorporateOwner' AND


### PR DESCRIPTION
These new functions establish a convention for working with multiple methods of ownership association, as well as a single overarching function that can combine all the methods together.

The convention for a single type of association is done as `regid -> regids`, i.e. input one registrationid and return any registrationids that might be associated given the particular method. This is now the convention in `sql/bisaddr_search.sql` and `sql/people_search.sql`.

All of this is brought together in `sql/combined_search.sql`, which unions multiple association methods and adds convenience translations to provide bbl -> regid -> regids -> addrs. The assumption (!) here is that even this very complex query is still more efficient than having to process multiple REST/AJAX calls to where the db is hosted.

`sql/array_cat_agg.sql` provides a custom aggregate function that concatenates arrays without messy unnesting.

